### PR TITLE
7.2: Initial support.

### DIFF
--- a/README72.md
+++ b/README72.md
@@ -1,0 +1,33 @@
+# Custom OpenBSD 7.2 Image Builder
+
+The `build72.sh` build script builds a custom `install72.iso` image from the official one.
+
+The machine running this script should be running OpenBSD 7.2 and have the same architecture as the target for the custom image.
+
+## Templates
+
+Each template may contain a `ramdisk.sh` script to customize the installation ramdisk and an `image.sh` script to customize the installation image. Either script can be omitted. Be sure to make them executable.
+
+The provided templates include both of these scripts. The scripts are documented and contain many examples of what you can do and how to do it.
+
+## Example Usage
+
+The build script must be run as root.
+
+```sh
+# Display all parameter descriptions and instructions.
+build72.sh --help
+
+# Build a release using the "example" template.
+build72.sh --template example
+```
+
+## Changes
+
+- The build script now handles compressed bsd.rd (ramdisk compression was added
+  at some point between OpenBSD 6.6. and 7.2)
+- The build script does `set -e` to handle subtle errors not caught by default
+
+## License
+
+This work is available under a BSD license as described in the LICENSE.txt file.

--- a/build72.sh
+++ b/build72.sh
@@ -1,0 +1,217 @@
+#!/bin/sh
+# Build a custom image of the OpenBSD 7.2 release.
+#
+# Author: Tim Baumgard
+# License: BSD (See LICENSE.txt)
+
+# ------------------------------------------------------------------------------
+
+set -e
+
+help() {
+	cat <<EOF
+Usage: $(basename "$0") [--help] [--mirror https://cdn.openbsd.org/pub/OpenBSD] --template example
+
+--help
+Display this help message and exit.
+
+--mirror
+URL of an OpenBSD mirror. It should be in the same format used by installurl(5).
+
+--template
+Name of the template to use when creating images. This parameter is required.
+EOF
+}
+
+status() {
+	echo "### $1"
+}
+
+warning() {
+	echo "!!! $1"
+}
+
+error() {
+	echo "ERROR: $1" >&2
+	exit 1
+}
+
+# ------------------------------------------------------------------------------
+
+# Defaults for the command-line parameters.
+MIRROR="https://cdn.openbsd.org/pub/OpenBSD"
+
+while :; do
+	case $1 in
+		--help|-h|-\?) help; exit 0 ;;
+		--mirror) MIRROR="$2" ;;
+		--template) TEMPLATE="$2" ;;
+		*) test "${#1}" -gt 0 || break ;;
+	esac
+
+	shift 2
+done
+
+ROOT_DIR="$(dirname "$(readlink -f "$0")")"
+RELEASE="$(uname -r)"
+ARCH="$(uname -m)"
+REL="${RELEASE%.[0-9]}${RELEASE#[0-9].}"
+IMAGES="${ROOT_DIR}/images"
+SOURCES="${ROOT_DIR}/sources"
+TEMPLATE_DIR="${ROOT_DIR}/templates/${RELEASE}/${ARCH}/${TEMPLATE}"
+TEMPLATE_IMAGE="${IMAGES}/${RELEASE}/${ARCH}/${TEMPLATE}/${TEMPLATE}${REL}.iso"
+
+if [ "$(id -u)" != "0" ]; then
+	error "This script must be run as root."
+fi
+
+if [ -z "${MIRROR}" -o -z "${TEMPLATE}" ]; then
+	error "Missing parameter(s). For help and example usage, try: $(basename "$0") --help"
+fi
+
+if [ ! -d "${ROOT_DIR}/templates/${RELEASE}/${ARCH}/${TEMPLATE}" ]; then
+	error "Template doesn't exist for ${RELEASE} release and ${ARCH} architecture."
+fi
+
+printf "- This script uses the /mnt directory. You must unmount any file systems that are currently using this directory.\n\n"
+printf "- This script uses vnd0. You must unmount any file systems using vnd0 and unconfigure it before continuing. See vnconfig(8).\n\n"
+echo -n "Continue? [y/N] "
+read CONTINUE
+
+case "${CONTINUE}" in
+	[Yy]*) ;;
+	*) exit;;
+esac
+
+status "Creating necessary files and directories."
+mkdir -p "${SOURCES}/${RELEASE}/${ARCH}"
+mkdir -p "${IMAGES}/${RELEASE}/${ARCH}/${TEMPLATE}"
+TEMP_IMAGE="$(mktemp -p "${ROOT_DIR}" -d image.XXXXXX)"
+TEMP_RAMDISK="$(mktemp -p "${ROOT_DIR}" ramdisk.XXXXXX)"
+
+status "Checking for OpenBSD source files and downloading them if necessary."
+
+set -A OPENBSD_SOURCES \
+	"${RELEASE}/${ARCH}/SHA256.sig" \
+	"${RELEASE}/${ARCH}/install${REL}.iso"
+
+for OPENBSD_SOURCE in ${OPENBSD_SOURCES[@]}; do
+	if [ ! -f "${SOURCES}/${OPENBSD_SOURCE}" ]; then
+		ftp -o "${SOURCES}/${OPENBSD_SOURCE}" "${MIRROR}/${OPENBSD_SOURCE}"
+
+		if [ $? -ne 0 ]; then
+			error "Download failed for ${MIRROR}/${OPENBSD_SOURCE}"
+		fi
+	fi
+done
+
+status "Verifying OpenBSD source files."
+
+for OPENBSD_SOURCE in ${OPENBSD_SOURCES[@]}; do
+	# Ignore files that weren't downloaded.
+	if [ ! -f "${SOURCES}/${OPENBSD_SOURCE}" ]; then
+		continue
+	fi
+
+	if [ "${OPENBSD_SOURCE#*SHA256}" == "${OPENBSD_SOURCE}" ]; then
+		(
+			cd "${SOURCES}/$(dirname "${OPENBSD_SOURCE}")"
+
+			signify -C \
+				-p "/etc/signify/openbsd-${REL}-base.pub" \
+				-x "SHA256.sig" \
+				"$(basename "${OPENBSD_SOURCE}")"
+
+			if [ $? -ne 0 ]; then
+				echo "Verification failed for ${MIRROR}/${OPENBSD_SOURCE}. The file should be deleted unless you manually downloaded or added it to the sources."
+				echo -n "Continue building? [y/N] "
+				read CONTINUE
+
+				case "${CONTINUE}" in
+					[Nn]*) exit 1;;
+				esac
+			fi
+		)
+	fi
+done
+
+status "Mounting and copying the source image."
+vnconfig vnd0 "${SOURCES}/${RELEASE}/${ARCH}/install${REL}.iso"
+mount -t cd9660 /dev/vnd0c /mnt
+cp -Rp /mnt/. "${TEMP_IMAGE}"
+umount /mnt
+vnconfig -u vnd0
+
+status "Mounting the new ramdisk image."
+rd="${TEMP_IMAGE}/${RELEASE}/${ARCH}/bsd.rd"
+rd_compressed=false
+case "$(file "${rd}")" in
+*'gzip compressed data'*)
+  rd_compressed=true
+  gzip -dc < "${rd}" > "${rd}.tmp"
+  mv "${rd}.tmp" "${rd}"
+  ;;
+*)
+  ;;                        
+esac
+rdsetroot -x "${TEMP_IMAGE}/${RELEASE}/${ARCH}/bsd.rd" "${TEMP_RAMDISK}"
+vnconfig vnd0 "${TEMP_RAMDISK}"
+mount /dev/vnd0a /mnt
+
+if [ -x "${TEMPLATE_DIR}/image.sh" ]; then
+	status "Calling the template image script."
+
+	(
+		export ARCH="${ARCH}"
+		export RELEASE="${RELEASE}"
+		export REL="${REL}"
+		export ROOT_DIR="${ROOT_DIR}"
+		export IMAGE_DIR="${TEMP_IMAGE}"
+		export TEMPLATE_DIR="${TEMPLATE_DIR}"
+		cd "${TEMP_IMAGE}"
+		"${TEMPLATE_DIR}/image.sh"
+	)
+elif [ -f "${TEMPLATE_DIR}/image.sh" ]; then
+	warning "A template image script was found but it's not executable."
+fi
+
+if [ -x "${TEMPLATE_DIR}/ramdisk.sh" ]; then
+	status "Calling the template ramdisk script."
+
+	(
+		export ARCH="${ARCH}"
+		export RELEASE="${RELEASE}"
+		export REL="${REL}"
+		export ROOT_DIR="${ROOT_DIR}"
+		export RAMDISK_DIR=/mnt
+		export TEMPLATE_DIR="${TEMPLATE_DIR}"
+		cd /mnt
+		"${TEMPLATE_DIR}/ramdisk.sh"
+	)
+elif [ -f "${TEMPLATE_DIR}/ramdisk.sh" ]; then
+	warning "A template ramdisk script was found but it's not executable."
+fi
+
+status "Unmounting and finalizing the new ramdisk image."
+umount /mnt
+vnconfig -u vnd0
+rdsetroot "${TEMP_IMAGE}/${RELEASE}/${ARCH}/bsd.rd" "${TEMP_RAMDISK}"
+if [ "${rd_compressed}" == "true"]; then
+  gzip < "${rd}" > "${rd}.tmp"
+  mv "${rd}.tmp" "${rd}"
+fi
+
+status "Creating the image."
+mkhybrid -a -R -T -L -l -d -D -N -o "${TEMPLATE_IMAGE}" -v -v \
+	-A "OpenBSD/${ARCH}	${RELEASE} Install CD" \
+	-P "Copyright (c) $(date +%Y) Theo de Raadt, The OpenBSD project" \
+	-p "Theo de Raadt <deraadt@openbsd.org>" \
+	-V "OpenBSD/${ARCH}	${RELEASE} Install CD" \
+	-b ${RELEASE}/${ARCH}/cdbr -c ${RELEASE}/${ARCH}/boot.catalog \
+	"${TEMP_IMAGE}"
+
+status "Removing temporary files."
+rm -rf "${TEMP_IMAGE}"
+rm -f "${TEMP_RAMDISK}"
+
+status "Done! The image is located at ${TEMPLATE_IMAGE}"

--- a/templates/7.2/amd64/builder/README.md
+++ b/templates/7.2/amd64/builder/README.md
@@ -1,0 +1,20 @@
+# OpenBSD 7.2 Builder Template
+
+First, build a release using this template or use a pre-built builder release to set up a build machine. Then, log in to the machine and start building.
+
+The password on the pre-built image for the `puffy` account is `puffy`, and the password for the `root` account is `root`.
+
+```sh
+# Log in to the build machine as puffy...
+
+# Build a release using the "example" template.
+doas -u root /home/puffy/build72.sh --template example
+
+# Clear out the images if necessary.
+doas -u root rm -rf /home/puffy/images
+
+# Clear out the sources if necessary.
+doas -u root rm -rf /home/puffy/sources
+```
+
+Note that the template lets OpenBSD automatically partition the drive. This means the drive will need to be around 10-15 GB to provide a reasonable amount of free space on the `/home` partition. Of course, you can always customize the template or the machine after installation if this is problematic.

--- a/templates/7.2/amd64/builder/auto_install.conf
+++ b/templates/7.2/amd64/builder/auto_install.conf
@@ -1,0 +1,13 @@
+# Use this file to specify the responses for an unattended installation. See
+# autoinstall(8) for more information and examples. Keep in mind that the this
+# file will take precedence if an auto_upgrade.conf file also exists.
+System hostname = puffy
+DNS domain name = example.net
+# The password, root, was hashed using encrypt(1).
+Password for root = $2b$10$R.LK0OPExF6FN.9zIpUP2.fQAkHh1KGTlrspPMr76FnQulEf0vPXe
+Do you expect to run the X Window System = no
+Setup a user = puffy
+# The password, puffy, was hashed using encrypt(1).
+Password for user = $2b$10$R3BFNcWpZdbUKOTyLTe83.PmLp7LI5MVAg2dACoFJhkuf52ShkmTW
+Set name(s) = +site* -comp* -game* -xbase* -xshare* -xfont* -xserv*
+Continue without verification = yes

--- a/templates/7.2/amd64/builder/image.sh
+++ b/templates/7.2/amd64/builder/image.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Use this script to customize the image and its contents before it's built. The
+# current working directory will be the root directory of the image.
+#
+# Useful variables:
+# $ARCH = the architecture of the machine and resulting image
+# $RELEASE = the OpenBSD release of the machine and resulting image
+# $REL = the OpenBSD release of the machine and resulting image without periods
+# $ROOT_DIR = the absolute path to root of the build scripts
+# $IMAGE_DIR = the absolute path to the custom image
+# $TEMPLATE_DIR = the absolute path to the template including this script
+
+# Remove the sets that aren't necessary for the builder. This will decrease the
+# size of the resulting image.
+(
+	cd "${RELEASE}/${ARCH}"
+	rm comp*.tgz game*.tgz xbase*.tgz xshare*.tgz xfont*.tgz xserv*.tgz
+)
+
+# Create a temporary directory used to create the siteXX.tgz file.
+TEMP_SITE="$(mktemp -p "${ROOT_DIR}" -d site.XXXXXX)"
+
+# Copy the existing siteXX files because they'll be customized below.
+cp -Rp "${TEMPLATE_DIR}/site${REL}/." "${TEMP_SITE}"
+
+# Copy over all the templates specific to the release and architecture.
+mkdir -p "${TEMP_SITE}/home/puffy/templates/${RELEASE}/${ARCH}"
+cp -p "${ROOT_DIR}/build${REL}.sh" "${TEMP_SITE}/home/puffy"
+cp -Rp "${ROOT_DIR}/templates/${RELEASE}/${ARCH}/." "${TEMP_SITE}/home/puffy/templates/${RELEASE}/${ARCH}"
+
+# Fix file and directory ownership. Proper ownership should really be set on the
+# files and directories in the site72 directory instead, but this is done here
+# since the development of this template isn't always done on OpenBSD.
+chown root:wheel "${TEMP_SITE}/etc"
+chown root:wheel "${TEMP_SITE}/etc/doas.conf"
+chown root:wheel "${TEMP_SITE}/install.site"
+
+# Package up the siteXX.tgz file and clean up.
+tar czf "${RELEASE}/${ARCH}/site${REL}.tgz" -C "${TEMP_SITE}" .
+rm -rf "${TEMP_SITE}"

--- a/templates/7.2/amd64/builder/ramdisk.sh
+++ b/templates/7.2/amd64/builder/ramdisk.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Use this script to customize the ramdisk image and its contents before it's
+# built. The current working directory will be the root directory of the ramdisk
+# image.
+#
+# Useful variables:
+# $ARCH = the architecture of the machine and resulting image
+# $RELEASE = the OpenBSD release of the machine and resulting image
+# $REL = the OpenBSD release of the machine and resulting image without periods
+# $ROOT_DIR = the absolute path to root of the build scripts
+# $RAMDISK_DIR = the absolute path to the custom ramdisk
+# $TEMPLATE_DIR = the absolute path to the template including this script
+
+# Add auto_install.conf for autoinstall(8).
+cp "${TEMPLATE_DIR}/auto_install.conf" .

--- a/templates/7.2/amd64/builder/site72/etc/doas.conf
+++ b/templates/7.2/amd64/builder/site72/etc/doas.conf
@@ -1,0 +1,5 @@
+permit puffy as root cmd rm args -rf /home/puffy/images
+permit puffy as root cmd rm args -rf /home/puffy/images/
+permit puffy as root cmd rm args -rf /home/puffy/sources
+permit puffy as root cmd rm args -rf /home/puffy/sources/
+permit puffy as root cmd /home/puffy/build66.sh

--- a/templates/7.2/amd64/builder/site72/install.site
+++ b/templates/7.2/amd64/builder/site72/install.site
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Use this script to complete a system after an unattended installation. See
+# https://www.openbsd.org/faq/faq4.html#site for more information about
+# install.site scripts.
+
+# eject(1) the CD so that the installer isn't loaded on reboot.
+eject /dev/rcd0c
+
+# Remove this script from the file system.
+rm /install.site

--- a/templates/7.2/amd64/ephemeral/README.md
+++ b/templates/7.2/amd64/ephemeral/README.md
@@ -1,0 +1,5 @@
+# OpenBSD Ephemeral Template
+
+This template is an experiment in creating single-use installations. This is done by using full-disk encryption secured by a keydisk that is erased the first time the system is booted. To be clear, this means that system will only be "ephemeral" if nobody retrieves the keydisk data between the time the system is installed and the first boot.
+
+The drive used is `sd0`. The password for the `puffy` account is `puffy`, and the password for the `root` account is `root`. Of course, these can be customized in the template.

--- a/templates/7.2/amd64/ephemeral/auto_install.conf
+++ b/templates/7.2/amd64/ephemeral/auto_install.conf
@@ -1,0 +1,13 @@
+# Use this file to specify the responses for an unattended installation. See
+# autoinstall(8) for more information and examples. Keep in mind that the this
+# file will take precedence if an auto_upgrade.conf file also exists.
+System hostname = puffy
+DNS domain name = example.net
+# The password, root, was hashed using encrypt(1).
+Password for root = $2b$10$R.LK0OPExF6FN.9zIpUP2.fQAkHh1KGTlrspPMr76FnQulEf0vPXe
+Setup a user = puffy
+# The password, puffy, was hashed using encrypt(1).
+Password for user = $2b$10$R3BFNcWpZdbUKOTyLTe83.PmLp7LI5MVAg2dACoFJhkuf52ShkmTW
+Which disk is the root disk = sd1
+Set name(s) = +site*
+Continue without verification = yes

--- a/templates/7.2/amd64/ephemeral/auto_install_prep.site
+++ b/templates/7.2/amd64/ephemeral/auto_install_prep.site
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Use this script to prepare a system immediately before an unattended
+# installation begins. Not all commands are available when installing.
+
+# Make sure the device file for the physical disk exists.
+(cd /dev && sh MAKEDEV sd0)
+
+# Overwrite the drive if it wasn't previously encrypted.
+# dd if=/dev/urandom of=/dev/rsd0c bs=1m
+
+# Clear the beginning of the disk to avoid issues with disk utilities.
+dd if=/dev/zero of=/dev/rsd0c bs=1m count=10
+
+# Set up the MBR and disklabel. This creates a 10 MB boot disk partition, a 10
+# MB keydisk partition, and the rest of the space is devoted to the partition
+# that will hold the OS and all user data. The order of the partitions is
+# important.
+fdisk -iy sd0
+echo "a a\n\n10m\n\na d\n\n10m\nRAID\na e\n\n*\nRAID\nw\nq\n" | disklabel -E sd0
+
+# Create a new file system for the boot disk and set up full-disk encryption on
+# the OS/data disk using the keydisk.
+newfs sd0a
+bioctl -c C -k sd0d -l sd0e softraid0
+
+# Make sure the device file for the softraid disk exists.
+(cd /dev && sh MAKEDEV sd1)
+
+# Clear the beginning of the OS/data disk to avoid issues with disk utilities.
+dd if=/dev/zero of=/dev/rsd1c bs=1m count=1
+
+# Randomize the hostname and DNS domain name if many of these systems are
+# expected to be generated on the fly.
+# myrandom="$RANDOM"
+# echo "System hostname = puffy$myrandom" >> /auto_install.conf
+# echo "DNS domain name = puffy$myrandom.example.net" >> /auto_install.conf

--- a/templates/7.2/amd64/ephemeral/image.sh
+++ b/templates/7.2/amd64/ephemeral/image.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Use this script to customize the image and its contents before it's built. The
+# current working directory will be the root directory of the image.
+#
+# Useful variables:
+# $ARCH = the architecture of the machine and resulting image
+# $RELEASE = the OpenBSD release of the machine and resulting image
+# $REL = the OpenBSD release of the machine and resulting image without periods
+# $ROOT_DIR = the absolute path to root of the build scripts
+# $IMAGE_DIR = the absolute path to the custom image
+# $TEMPLATE_DIR = the absolute path to the template including this script
+
+# Create a temporary directory used to create the siteXX.tgz file.
+TEMP_SITE="$(mktemp -p "${ROOT_DIR}" -d site.XXXXXX)"
+
+# Copy the existing siteXX files.
+cp -Rp "${TEMPLATE_DIR}/site${REL}/." "${TEMP_SITE}"
+
+# Fix file and directory ownership. Proper ownership should really be set on the
+# files and directories in the site72 directory instead, but this is done here
+# since the development of this template isn't always done on OpenBSD.
+chown root:wheel "${TEMP_SITE}/install.site"
+
+# Package up the siteXX.tgz file and clean up.
+tar czf "${RELEASE}/${ARCH}/site${REL}.tgz" -C "${TEMP_SITE}" .
+rm -rf "${TEMP_SITE}"

--- a/templates/7.2/amd64/ephemeral/ramdisk.sh
+++ b/templates/7.2/amd64/ephemeral/ramdisk.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Use this script to customize the ramdisk image and its contents before it's
+# built. The current working directory will be the root directory of the ramdisk
+# image.
+#
+# Useful variables:
+# $ARCH = the architecture of the machine and resulting image
+# $RELEASE = the OpenBSD release of the machine and resulting image
+# $REL = the OpenBSD release of the machine and resulting image without periods
+# $ROOT_DIR = the absolute path to root of the build scripts
+# $RAMDISK_DIR = the absolute path to the custom ramdisk
+# $TEMPLATE_DIR = the absolute path to the template including this script
+
+# Add auto_install.conf for autoinstall(8).
+cp "${TEMPLATE_DIR}/auto_install.conf" .
+
+# Patch the installer to allow for automatic installation prep.
+patch -p1 < "${TEMPLATE_DIR}/install.sub.patch"
+rm install.sub.orig
+
+# Add auto_install_prep.site for automatic installation prep.
+cp "${TEMPLATE_DIR}/auto_install_prep.site" .

--- a/templates/7.2/amd64/ephemeral/site72/install.site
+++ b/templates/7.2/amd64/ephemeral/site72/install.site
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Use this script to complete a system after an unattended installation. See
+# https://www.openbsd.org/faq/faq4.html#site for more information
+# about install.site scripts.
+
+# eject(1) the CD so that the installer isn't loaded on reboot.
+eject /dev/rcd0c
+
+# Set the system to overwrite the keydisk with random data and then zeroes.
+echo "dd if=/dev/urandom of=/dev/rsd0d" >> /etc/rc.firsttime
+echo "dd if=/dev/zero of=/dev/rsd0d" >> /etc/rc.firsttime
+
+# Mount the boot drive to modify it.
+mount /dev/sd0a /mnt
+
+# Tweak the default boot configuration to boot the correct disk and partition.
+mkdir /mnt/etc
+echo "boot sr0a:/bsd" > /mnt/etc/boot.conf
+
+# Install a new bootstrap to the boot drive.
+cp /usr/mdec/boot /mnt/boot
+installboot -v -r /mnt sd0 /usr/mdec/biosboot /usr/mdec/boot

--- a/templates/7.2/amd64/example/auto_install.conf
+++ b/templates/7.2/amd64/example/auto_install.conf
@@ -1,0 +1,12 @@
+# Use this file to specify the responses for an unattended upgrade. See
+# autoinstall(8) for more information and examples. Keep in mind that the this
+# file will take precedence if an auto_upgrade.conf file also exists.
+System hostname = puffy
+DNS domain name = example.net
+# The password, root, was hashed using encrypt(1).
+Password for root = $2b$10$R.LK0OPExF6FN.9zIpUP2.fQAkHh1KGTlrspPMr76FnQulEf0vPXe
+Setup a user = puffy
+# The password, puffy, was hashed using encrypt(1).
+Password for user = $2b$10$R3BFNcWpZdbUKOTyLTe83.PmLp7LI5MVAg2dACoFJhkuf52ShkmTW
+Set name(s) = +site* -game*
+Continue without verification = yes

--- a/templates/7.2/amd64/example/auto_install_prep.site
+++ b/templates/7.2/amd64/example/auto_install_prep.site
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Use this script to prepare a system immediately before an unattended
+# installation begins. Not all commands are available when installing.
+
+echo "Executing the auto_install_prep.site script."

--- a/templates/7.2/amd64/example/auto_upgrade.conf
+++ b/templates/7.2/amd64/example/auto_upgrade.conf
@@ -1,0 +1,3 @@
+# Use this file to specify the responses for an unattended upgrade. See
+# autoinstall(8) for more information and examples. Keep in mind that the
+# auto_install.conf file will take precedence if it also exists.

--- a/templates/7.2/amd64/example/auto_upgrade_prep.site
+++ b/templates/7.2/amd64/example/auto_upgrade_prep.site
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Use this script to prepare a system immediately before an unattended upgrade
+# begins. Not all commands are available when upgrading.
+
+echo "Executing the auto_upgrade_prep.site script."

--- a/templates/7.2/amd64/example/image.sh
+++ b/templates/7.2/amd64/example/image.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Use this script to customize the image and its contents before it's built. The
+# current working directory will be the root directory of the image.
+#
+# Useful variables:
+# $ARCH = the architecture of the machine and resulting image
+# $RELEASE = the OpenBSD release of the machine and resulting image
+# $REL = the OpenBSD release of the machine and resulting image without periods
+# $ROOT_DIR = the absolute path to root of the build scripts
+# $IMAGE_DIR = the absolute path to the custom image
+# $TEMPLATE_DIR = the absolute path to the template including this script
+
+# Create a temporary directory used to create the siteXX.tgz file.
+TEMP_SITE="$(mktemp -p "${ROOT_DIR}" -d site.XXXXXX)"
+
+# Copy the existing siteXX files because they'll be customized below.
+cp -Rp "${TEMPLATE_DIR}/site${REL}/." "${TEMP_SITE}"
+
+# Fix file and directory ownership. Proper ownership should really be set on the
+# files and directories in the site72 directory instead, but this is done here
+# since the development of this template isn't always done on OpenBSD.
+chown root:wheel "${TEMP_SITE}/usr"
+chown root:wheel "${TEMP_SITE}/usr/local"
+chown root:wheel "${TEMP_SITE}/usr/local/bin"
+chown root:bin "${TEMP_SITE}/usr/local/bin/test.sh"
+
+# Package up the siteXX.tgz file and clean up.
+tar czf "${RELEASE}/${ARCH}/site${REL}.tgz" -C "${TEMP_SITE}" .
+rm -rf "${TEMP_SITE}"
+
+# Alternatively, if developing on OpenBSD and the proper ownership for the
+# siteXX files and directories is set using chown, this entire script could be
+# reduced to the following:
+# tar czf "${RELEASE}/${ARCH}/site${REL}.tgz" -C "${TEMPLATE_DIR}/site{$REL}" .

--- a/templates/7.2/amd64/example/ramdisk.sh
+++ b/templates/7.2/amd64/example/ramdisk.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Use this script to customize the ramdisk image and its contents before it's
+# built. The current working directory will be the root directory of the ramdisk
+# image.
+#
+# Useful variables:
+# $ARCH = the architecture of the machine and resulting image
+# $RELEASE = the OpenBSD release of the machine and resulting image
+# $REL = the OpenBSD release of the machine and resulting image without periods
+# $ROOT_DIR = the absolute path to root of the build scripts
+# $RAMDISK_DIR = the absolute path to the custom ramdisk
+# $TEMPLATE_DIR = the absolute path to the template including this script
+
+# Add auto_install.conf and auto_upgrade.conf for autoinstall(8).
+cp "${TEMPLATE_DIR}/auto_install.conf" .
+cp "${TEMPLATE_DIR}/auto_upgrade.conf" .
+
+# Patch the installer to allow for automatic installation prep.
+patch -p1 < "${TEMPLATE_DIR}/install.sub.patch"
+rm install.sub.orig
+
+# Add auto_install_prep.site and auto_upgrade_prep.site scripts for automatic
+# installation prep.
+cp "${TEMPLATE_DIR}/auto_install_prep.site" .
+cp "${TEMPLATE_DIR}/auto_upgrade_prep.site" .

--- a/templates/7.2/amd64/example/site72/install.site
+++ b/templates/7.2/amd64/example/site72/install.site
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Use this script to complete a system after an unattended installation. See
+# https://www.openbsd.org/faq/faq4.html#site for more information
+# about install.site scripts.
+
+echo "Executing the install.site script."
+
+# eject(1) the CD so that the installer isn't loaded on reboot.
+eject /dev/rcd0c

--- a/templates/7.2/amd64/example/site72/upgrade.site
+++ b/templates/7.2/amd64/example/site72/upgrade.site
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Use this script to complete a system after an unattended upgrade. See
+# https://www.openbsd.org/faq/faq4.html#site for more information about
+# upgrade.site scripts.
+
+echo "Executing the upgrade.site script."
+
+# eject(1) the CD so that the installer isn't loaded on reboot.
+eject /dev/rcd0c

--- a/templates/7.2/amd64/example/site72/usr/local/bin/test.sh
+++ b/templates/7.2/amd64/example/site72/usr/local/bin/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This is just a dummy script.
+
+echo "You have executed test.sh"


### PR DESCRIPTION
The primary change between 6.6 (the last supported version) and 7.2 appears to be that the bsd.rd (ramdisk) is now gzip compressed. This commit checks if the file is compressed and performs the necessary compression operations.